### PR TITLE
upgrade from f1-micro to e2-micro

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "google_compute_firewall" "allow_http" {
 
 resource "google_compute_instance" "default" {
   name         = "automuteus"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
 
   tags = ["allow-http"]
 


### PR DESCRIPTION
gce の f1-micro を無料枠として利用していたが、f1-micro が有料になり、e2-micro が無料枠になっていたので、修正します

cf. https://can.ne.jp/2021/07/21/gcp%E3%81%AE%E7%84%A1%E6%96%99%E3%82%AF%E3%83%A9%E3%82%A6%E3%83%89vm%E3%81%8C%E6%80%A7%E8%83%BD%E3%82%A2%E3%83%83%E3%83%97%E3%81%99%E3%82%8B%E3%82%89%E3%81%97%E3%81%84f1-micro-%E2%86%92-e2-micro/